### PR TITLE
Updating nodes-min 0 on scale-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ prevent extra costs you can scale down your clusters using `eksctl` as follows:
 ```bash
 $ eksctl get clusters
 $ eksctl get nodegroup --cluster eks
-$ eksctl scale nodegroup --cluster=eks --nodes=0 ng-xxxxxxx
+$ eksctl scale nodegroup --cluster=eks --nodes=0 --nodes-min=0 ng-xxxxxxx
 ```
 
 _Note: As of 2019-09-30 there is a bug with the above command [github/issues/809](https://github.com/weaveworks/eksctl/issues/809) that does not update the min value of the auto scaling group. To get around this scale the nodes to 0, then to 1 and then to 0 again (using the last command above)._


### PR DESCRIPTION
The default nodes-min is set to 2. Hence anyone following this and wants to scale down would need to set the nodes-min to 0